### PR TITLE
Add theme toggle and chat history controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,114 +1,76 @@
 <!DOCTYPE html>
-<html lang="en">
-<head> 
-<meta charset="UTF-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/js/all.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
-<title>Document</title>
-
-<style>
-  #loader {
-  position: fixed;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  background-color: #000000;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 9999;
-}
-
-  </style>
-
-
-
-<body>
-  
-
-<div id="loader">
-
-   <img src="./img/3d8064758e54ec662e076b6ca54aa90e.gif" alt="Loading...">
-  
-
-</div>
-
-
-<div1 id="currentDateTime"></div1>
-
-<div2 id="network-status">
-
-  <span1 id="status-text"></span>
-    
-</div2>
-    
-<button onclick="speech()" id="assistantButton">
-  
-    <img src="./img/главная кнопка.jpg" alt="Assistant Icon">
-
-</button>
-
-<div class="burger-menu">
-
-  <p id="hidden-paragraph"></p>
-
- <button onclick="toggleVisibility()"></button><button onclick="toggleVisibility()">
-
-    <img src="./img/кнопка для меню.jpg" alt="Изображение кнопки">
-
- </button>
-  
-  <!-- <div class="menu-item">Burger 1</div>
-  <div class="menu-item">Burger 2</div>
-  <div class="menu-item">Burger 3</div>
-  <div class="menu-item">Burger 4</div>
-  <div class="menu-item">Burger 5</div> -->
-</div>
-
-
-
-<div id="frame-icon">
-
-  <img class="frame-icon" src="./img/рамка для wifi.jpg" alt="Картинка">
-
-</div>
-
-<div id="logoFrame">
-
-  <img class="logoFrame" src="./img/рамка под логотип.jpg" alt="logo-frame">
-
-  <img class="custom-icon" src="./img/логотип1.jpg" alt="AI" class="custom-icon">
-  
-</div>
-
-<div id="analysis">
-
-  <img class="frame-analysis" src="./img/рамка анализа .jpg" alt="frame-analysis">
-
-  <img class="analysis" src="./img/Аналитика.gif" alt="analysis">
-
-</div>
-
-
-<script>
-
-  window.addEventListener("load", function() {
-  var loader = document.getElementById("loader");
-  setTimeout(function() {
-    loader.style.display = "none";
-  }, 2000); // 2000 миллисекунд = 2 секунды
-});
-
-
-  </script>
-
-<link rel="stylesheet" href="s.css">
-<script src="script.js"></script>
-
-</body>
-
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/js/all.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+  <link rel="stylesheet" href="s.css">
+  <title>Document</title>
 </head>
+<body>
+  <div id="loader">
+    <img src="./img/3d8064758e54ec662e076b6ca54aa90e.gif" alt="Loading...">
+  </div>
+
+  <div id="currentDateTime"></div>
+
+  <div id="network-status">
+    <span id="status-text"></span>
+  </div>
+
+  <button onclick="speech()" id="assistantButton">
+    <img src="./img/главная кнопка.jpg" alt="Assistant Icon">
+  </button>
+
+  <div class="burger-menu">
+    <p id="hidden-paragraph"></p>
+    <div id="voice-controls">
+      <select id="voiceSelect"></select>
+      <label for="rate">Скорость</label>
+      <input id="rate" type="range" min="0.5" max="2" step="0.1" value="1">
+      <label for="pitch">Тон</label>
+      <input id="pitch" type="range" min="0" max="2" step="0.1" value="1">
+      <label for="volume">Громкость</label>
+      <input id="volume" type="range" min="0" max="1" step="0.1" value="1">
+    </div>
+    <div id="chat-history"></div>
+    <div id="menu-actions">
+      <button id="clear-history-btn">Очистить историю</button>
+      <label class="theme-switch">
+        <input type="checkbox" id="theme-switch">
+        Светлая тема
+      </label>
+    </div>
+    <button onclick="toggleVisibility()">
+      <img src="./img/кнопка для меню.jpg" alt="Изображение кнопки">
+    </button>
+  </div>
+
+  <div id="frame-icon">
+    <img class="frame-icon" src="./img/рамка для wifi.jpg" alt="Картинка">
+  </div>
+
+  <div id="logoFrame">
+    <img class="logoFrame" src="./img/рамка под логотип.jpg" alt="logo-frame">
+    <img class="custom-icon" src="./img/логотип1.jpg" alt="AI">
+  </div>
+
+  <div id="analysis">
+    <img class="frame-analysis" src="./img/рамка анализа .jpg" alt="frame-analysis">
+    <img class="analysis" src="./img/Аналитика.gif" alt="analysis">
+  </div>
+
+  <script>
+    window.addEventListener("load", function () {
+      var loader = document.getElementById("loader");
+      setTimeout(function () {
+        loader.style.display = "none";
+      }, 2000);
+    });
+  </script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/s.css
+++ b/s.css
@@ -1,214 +1,273 @@
+* {
+  box-sizing: border-box;
+}
 
 body {
-  margin: 20px;
-  width: 430px;
-  height: 740px;
+  margin: 0;
+  padding: 20px;
+  width: 100%;
+  min-height: 100vh;
   background-image: url("./img/ФОН.jpg");
   background-size: cover;
   background-position: center;
   background-attachment: fixed;
+  font-family: "Oswald", Arial, sans-serif;
 }
 
+body.light-theme {
+  background-image: none;
+  background-color: #ffffff;
+  color: #000;
+}
+
+body.light-theme #currentDateTime,
+body.light-theme #status-text {
+  color: #000;
+}
+
+body.light-theme #voice-controls,
+body.light-theme #chat-history,
+body.light-theme #menu-actions,
+body.light-theme #hidden-paragraph {
+  background: rgba(255, 255, 255, 0.8);
+  color: #000;
+}
+
+body.light-theme #menu-actions button {
+  background: rgba(0, 0, 0, 0.1);
+  color: #000;
+}
+
+#loader {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #000000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+}
 
 #currentDateTime {
-  width: 70px;
-  height: 130px;
-  font-size: 14px;
+  width: 18vw;
+  max-width: 80px;
+  min-width: 60px;
+  height: auto;
+  font-size: clamp(12px, 3vw, 14px);
   font-family: "Courier New", monospace;
   display: flex;
   flex-direction: column;
   align-items: center;
   color: #25b6aa;
-  background-image: url("./img/рамка\ для\ часов.jpg");
+  background-image: url("./img/рамка\\ для\\ часов.jpg");
   background-size: cover;
   background-position: center;
   justify-content: center;
   text-align: center;
   position: fixed;
-  top: 0px;
-  right: 0px;
+  top: 1rem;
+  right: 1rem;
 }
 
- 
-   #assistantButton {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 70px;
-    height: 70px;
-    background-color: #0b0c0c;
-    color: #000000;
-    font-size: 16px;
-    border: none;
-    border-radius: 50%;
-    cursor: pointer;
-    overflow: hidden;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
-  
-    position: fixed;
-    bottom: 20px;
-    left: 50%;
-    transform: translateX(-50%);
-  }
-  
-  #assistantButton img {
-    width: 100px;
-    height: 100px;
-    display: block;
-    margin: 0 auto;
-  }
-  
-  
-  #assistantButton:hover {
-    background-color: #000000;
-  }
-  
+#assistantButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18vw;
+  height: 18vw;
+  max-width: 80px;
+  max-height: 80px;
+  background-color: #0b0c0c;
+  color: #000000;
+  font-size: 16px;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  overflow: hidden;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+}
 
-  .burger-menu {
-    position: relative;
-    color: #33b6d8ff;
-    border: none;
-    border-image: linear-gradient(45deg, #33b6d8ff, #00396eff, #33b6d8ff);
-    border-image-slice: 1;
-    overflow: auto;
-    max-height: 50vh;
-    align-self: flex-end;
-    font-family: "Oswald", Arial, sans-serif;
-    padding: 20px;
-    box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.25);
-  }
-  
-  .burger-menu::before {
-    content: "";
-    position: fixed;
-    top: 600px;
-    right: 0px;
-    width: 200px;
-    height: 100px;
-    background-image: url(./img/рамка\ для\ меню\ .jpg);
-    background-size: cover;
-    background-position: center;
-    /* opacity: 0.5; */
-    z-index: -1;
-  }
-  
-  .menu-item {
-    margin-bottom: 10px;
-    transition: transform 0.3s ease-in-out;
-  }
-  
-  .menu-item:hover {
-    transform: scale(1.1);
-  }
-  
-  
-  .menu-item {
-    margin-bottom: 10px;
-    transition: transform 0.3s ease-in-out;
-  }
-  
-  .menu-item:hover {
-    transform: scale(1.1);
-  }
-  
-  
-  #hidden-paragraph {
-    display: none;
-    color: #33b6d8ff;
-    position: fixed;
-    top: 300px;
-    right: 220px;
-    border: none; 
-    background-image: url(./img/РАМКА\ ПОД\ ТЕКСТ.jpg); 
-    background-size: cover;
-    background-position: center;
-    overflow: auto;
-    max-height: 50vh;
-    align-self: flex-end;
-    font-family: "Courier New", monospace;
-  }
-  
-  #hidden-paragraph {
-    display: none;
-    color: #33b6d8ff; 
-    border-image-slice: 2;
-    overflow: auto;
-    max-height: 50vh;
-    align-self: flex-end;
-    font-family: "Courier New", monospace;
-    text-align: center;
-    font-size: 14px;
-    margin-top: 10px;
-  }
+#assistantButton img {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
 
-  .burger-menu button {
-    width: 50px;
-    height: 50px;
-    position: fixed;
-    top: 625px;
-    right: 40px;
-    border: none;
-    background: none;
-    cursor: pointer;
-    padding: 0;
-    margin: 0;
-    display: inline-block;
-    vertical-align: middle;
-    border-radius: 50%;
-    cursor: pointer;
-    overflow: hidden;
-  }
+.burger-menu {
+  position: relative;
+  color: #33b6d8ff;
+  border: none;
+  border-image: linear-gradient(45deg, #33b6d8ff, #00396eff, #33b6d8ff);
+  border-image-slice: 1;
+  overflow: auto;
+  max-height: 50vh;
+  align-self: flex-end;
+  font-family: "Oswald", Arial, sans-serif;
+  padding: 20px;
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.25);
+}
 
-  .burger-menu img {
-    width: 50px;
-    height: 50px;
-  }
+.burger-menu::before {
+  content: "";
+  position: fixed;
+  bottom: 90px;
+  right: 0;
+  width: 40vw;
+  max-width: 200px;
+  height: 20vw;
+  max-height: 100px;
+  background-image: url(./img/рамка\\ для\\ меню\\ .jpg);
+  background-size: cover;
+  background-position: center;
+  z-index: -1;
+}
 
-  .menu-item {
-    margin: 10px 0;
-    padding: 5px;
-    background-color: #f8f8f8;
-    border-radius: 5px;
-    cursor: pointer;
-  }
-  
-  
-  
-  @media screen and (max-width: 800px) {
-    button, p {
-      width: 50%;
-      margin-left: 0;
-    }
-  
-    p {
-      font-size: 3vh;
-    }
-  }
-  
-  @keyframes button_anim {
-    from {
-      opacity: 1;
-    }
-    to {
-      opacity: 1;
-    }
-    50% {
-      opacity: 0.2;
-    }
-  }
-  #div2 {
-    position: fixed;
-    top: 15px;
-    right: 15px;
+#hidden-paragraph {
+  display: none;
+  color: #33b6d8ff;
+  position: fixed;
+  bottom: 150px;
+  right: 20px;
+  border: none;
+  background-image: url(./img/РАМКА\\ ПОД\\ ТЕКСТ.jpg);
+  background-size: cover;
+  background-position: center;
+  overflow: auto;
+  max-height: 50vh;
+  align-self: flex-end;
+  font-family: "Courier New", monospace;
+  text-align: center;
+  font-size: 14px;
+  margin-top: 10px;
+}
+
+#voice-controls {
+  display: none;
+  color: #33b6d8ff;
+  position: fixed;
+  bottom: 300px;
+  right: 20px;
+  width: 60vw;
+  max-width: 250px;
+  background: rgba(0, 0, 0, 0.6);
+  padding: 10px;
+  border-radius: 8px;
+  font-family: "Oswald", Arial, sans-serif;
+}
+
+#voice-controls label {
+  font-size: 12px;
+  display: block;
+  margin-top: 5px;
+}
+
+#voice-controls select,
+#voice-controls input {
+  width: 100%;
+  margin-top: 5px;
+  background: rgba(0, 0, 0, 0.3);
+  color: #33b6d8ff;
+  border: none;
+  border-radius: 4px;
+}
+
+#chat-history {
+  display: none;
+  color: #33b6d8ff;
+  position: fixed;
+  bottom: 150px;
+  right: 20px;
+  width: 60vw;
+  max-width: 250px;
+  background: rgba(0, 0, 0, 0.6);
+  padding: 10px;
+  border-radius: 8px;
+  font-family: "Courier New", monospace;
+  font-size: 12px;
+  max-height: 30vh;
+  overflow-y: auto;
+}
+
+#menu-actions {
+  display: none;
+  color: #33b6d8ff;
+  position: fixed;
+  bottom: 90px;
+  right: 20px;
+  width: 60vw;
+  max-width: 250px;
+  background: rgba(0, 0, 0, 0.6);
+  padding: 10px;
+  border-radius: 8px;
+  font-family: "Oswald", Arial, sans-serif;
+  text-align: center;
+}
+
+#menu-actions button {
+  width: 100%;
+  background: rgba(0, 0, 0, 0.3);
+  color: #33b6d8ff;
+  border: none;
+  border-radius: 4px;
+  padding: 5px;
+  margin-bottom: 10px;
+}
+
+.theme-switch {
+  font-size: 12px;
+  display: block;
+}
+
+.theme-switch input {
+  margin-right: 5px;
+}
+
+#chat-history .user {
+  color: #16bacf;
+}
+
+#chat-history .assistant {
+  color: #ffffff;
+}
+
+.burger-menu button {
+  width: 15vw;
+  height: 15vw;
+  max-width: 60px;
+  max-height: 60px;
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
+  display: inline-block;
+  vertical-align: middle;
+  border-radius: 50%;
+  overflow: hidden;
+}
+
+.burger-menu img {
+  width: 100%;
+  height: 100%;
 }
 
 #status-text {
-    font-size: 16px;
-    position: absolute;
-    top: 30px;
-    right: 0px;
-    justify-content: center;
-    text-align: center;
+  font-size: 16px;
+  position: absolute;
+  top: 30px;
+  right: 0px;
+  justify-content: center;
+  text-align: center;
 }
 
 #status-icon {
@@ -219,45 +278,60 @@ body {
 
 .frame-icon {
   display: block;
-  width: 70px;
-  height: 80px;
+  width: 18vw;
+  max-width: 70px;
+  height: auto;
   position: fixed;
   top: 0px;
-  right: 70px;
+  right: 15vw;
 }
 
 .logoFrame {
   display: block;
-  width: 70px;
-  height: 80px;
+  width: 18vw;
+  max-width: 70px;
+  height: auto;
   position: fixed;
   top: 0px;
-  right: 110px;
+  right: calc(15vw + 18vw);
 }
 
 .custom-icon {
-  width: 50px;
-  height: 40px;
+  width: 14vw;
+  max-width: 50px;
+  height: auto;
   position: fixed;
   top: 18px;
-  right: 120px;
-  
+  right: calc(15vw + 18vw + 5vw);
 }
 
-.frame-analysis{
-  width: 240px;
-  height: 80px;
+.frame-analysis {
+  width: 55vw;
+  max-width: 240px;
+  height: auto;
   position: fixed;
   top: 0;
-  right: 175px;
+  right: calc(15vw + 18vw + 18vw + 5vw);
 }
 
-.analysis{
+.analysis {
   display: block;
-  width: 215px;
-  height: 70px;
+  width: 50vw;
+  max-width: 215px;
+  height: auto;
   position: fixed;
   top: 5px;
-  right: 190px;
+  right: calc(15vw + 18vw + 18vw + 8vw);
 }
 
+@media (min-width: 768px) {
+  #assistantButton,
+  .burger-menu button {
+    width: 80px;
+    height: 80px;
+  }
+
+  #currentDateTime {
+    font-size: 16px;
+  }
+}

--- a/script.js
+++ b/script.js
@@ -5,7 +5,7 @@ let apiKey = 'тут должен бытть ваш api ключь '
 // ПЕРЕМЕННЫЕ
 let button = window.document.querySelector('button');
 let p = window.document.querySelector('p');
-let conversation = [];
+let conversation = JSON.parse(localStorage.getItem('conversation') || '[]');
 
 
 // Для распознавания речи
@@ -14,6 +14,91 @@ let speechRecognizer = new webkitSpeechRecognition();
 
 // Для синтез речи
 let speechSynthesis = window.speechSynthesis;
+const voiceSelect = document.getElementById('voiceSelect');
+const rateInput = document.getElementById('rate');
+const pitchInput = document.getElementById('pitch');
+const volumeInput = document.getElementById('volume');
+let voices = [];
+const chatHistory = document.getElementById('chat-history');
+const themeSwitch = document.getElementById('theme-switch');
+const clearHistoryBtn = document.getElementById('clear-history-btn');
+
+const populateVoices = () => {
+  voices = speechSynthesis.getVoices();
+  if (!voices.length) return;
+  voiceSelect.innerHTML = '';
+  voices.forEach((voice) => {
+    const option = document.createElement('option');
+    option.value = voice.name;
+    option.textContent = `${voice.name} (${voice.lang})`;
+    voiceSelect.appendChild(option);
+  });
+  const savedVoice = localStorage.getItem('voice');
+  if (savedVoice && voices.find((v) => v.name === savedVoice)) {
+    voiceSelect.value = savedVoice;
+  } else if (voices.length > 0 && !voiceSelect.value) {
+    voiceSelect.value = voices[0].name;
+  }
+};
+
+speechSynthesis.onvoiceschanged = populateVoices;
+populateVoices();
+
+voiceSelect.addEventListener('change', () => {
+  localStorage.setItem('voice', voiceSelect.value);
+});
+
+rateInput.value = localStorage.getItem('rate') || '1';
+pitchInput.value = localStorage.getItem('pitch') || '1';
+volumeInput.value = localStorage.getItem('volume') || '1';
+
+rateInput.addEventListener('input', () => {
+  localStorage.setItem('rate', rateInput.value);
+});
+
+pitchInput.addEventListener('input', () => {
+  localStorage.setItem('pitch', pitchInput.value);
+});
+
+volumeInput.addEventListener('input', () => {
+  localStorage.setItem('volume', volumeInput.value);
+});
+
+const saveConversation = () => {
+  localStorage.setItem('conversation', JSON.stringify(conversation));
+};
+
+const updateChatHistory = () => {
+  if (!chatHistory) return;
+  chatHistory.innerHTML = conversation
+    .map((msg) => `<div class="${msg.role}">${msg.role === 'user' ? 'Вы' : 'ИИ'}: ${msg.content}</div>`)
+    .join('');
+};
+
+updateChatHistory();
+
+const applyTheme = (theme) => {
+  document.body.classList.toggle('light-theme', theme === 'light');
+  localStorage.setItem('theme', theme);
+  if (themeSwitch) themeSwitch.checked = theme === 'light';
+};
+
+const savedTheme = localStorage.getItem('theme') || 'dark';
+applyTheme(savedTheme);
+
+if (themeSwitch) {
+  themeSwitch.addEventListener('change', () => {
+    applyTheme(themeSwitch.checked ? 'light' : 'dark');
+  });
+}
+
+if (clearHistoryBtn) {
+  clearHistoryBtn.addEventListener('click', () => {
+    conversation = [];
+    saveConversation();
+    updateChatHistory();
+  });
+}
 
 
 // ФУНКЦИИ
@@ -26,30 +111,18 @@ const speech = () => {
 
 const talk = (text) => {
 if ('speechSynthesis' in window) {
-const textToTalk = new SpeechSynthesisUtterance(text);
-textToTalk.rate = 1.1; // Скорость речи (0.1 - 10)
-textToTalk.pitch = 1.0; // Высота тона речи (0 - 2)
-textToTalk.volume = 1.0; // Громкость речи (0 - 1)
-textToTalk.lang = 'ru-RU'; // Язык речи (например, 'en-US', 'ru-RU')
-textToTalk.voiceURI = 'Microsoft Zira Desktop'; 
-textToTalk.voice = speechSynthesis.getVoices()[0]; // Выбор конкретного голоса из доступных
-
-
-//поиск женского голоса 
-const femaleVoices = voices.filter((voice) => voice.gender === 'female');
-const gentlestFemaleVoice = femaleVoices.reduce(
-(gentlestVoice, currentVoice) =>
-currentVoice.pitch < gentlestVoice.pitch ? currentVoice : gentlestVoice,
-femaleVoices[0]
-);
-
-
-// Настройка голоса
-textToTalk.voice = gentlestFemaleVoice;
-
-speechSynthesis.speak(textToTalk);
+  const utterance = new SpeechSynthesisUtterance(text);
+  const selectedVoice = voices.find((voice) => voice.name === voiceSelect.value);
+  if (selectedVoice) {
+    utterance.voice = selectedVoice;
+    utterance.lang = selectedVoice.lang;
+  }
+  utterance.rate = parseFloat(rateInput.value);
+  utterance.pitch = parseFloat(pitchInput.value);
+  utterance.volume = parseFloat(volumeInput.value);
+  speechSynthesis.speak(utterance);
 } else {
-console.error('Speech synthesis is not supported in this browser.');
+  console.error('Speech synthesis is not supported in this browser.');
 }
 };
 
@@ -72,6 +145,8 @@ role: 'user',
 content: p.innerText,
 };
 conversation.push(message);
+saveConversation();
+updateChatHistory();
 
 const params = {
 model: 'gpt-3.5-turbo',
@@ -87,6 +162,8 @@ role: 'assistant',
 content: response.data.choices[0].message.content,
 };
 conversation.push(gptMessage);
+saveConversation();
+updateChatHistory();
 
 p.innerText = gptMessage.content;
 button.innerHTML = '<img src="./img/кнопка.jpg">';
@@ -106,10 +183,19 @@ console.error('Error while making the request:', error);
 
 function toggleVisibility() {
   var paragraph = document.getElementById("hidden-paragraph");
+  var controls = document.getElementById("voice-controls");
+  var history = document.getElementById("chat-history");
+  var actions = document.getElementById("menu-actions");
   if (paragraph.style.display === "none") {
     paragraph.style.display = "block";
+    controls.style.display = "block";
+    history.style.display = "block";
+    if (actions) actions.style.display = "block";
   } else {
     paragraph.style.display = "none";
+    controls.style.display = "none";
+    history.style.display = "none";
+    if (actions) actions.style.display = "none";
   }
 }
 
@@ -137,15 +223,18 @@ statusIcon.id = "status-icon";
 // Добавляем элемент в тело документа
 document.body.appendChild(statusIcon);
 
+var statusText = document.getElementById("status-text");
+
 
 // Функция для обновления состояния сети интернет
 function updateNetworkStatus() {
   var statusIcon = document.getElementById("status-icon");
-  
   if (navigator.onLine) {
     statusIcon.innerHTML = '<i class="fas fa-wifi" style="color: #16bacf;"></i>';
+    if (statusText) statusText.textContent = 'Online';
   } else {
     statusIcon.innerHTML = '<i class="fas fa-wifi" style="color: red;"></i>';
+    if (statusText) statusText.textContent = 'Offline';
   }
 }
 


### PR DESCRIPTION
## Summary
- Add light theme switch and chat history clear button in burger menu
- Style menu actions and support light theme for mobile interface
- Persist chosen theme using local storage

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a697db8b28832ab6aa05bc5e61dc81