### PR TITLE
feat: redesign interface without images

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,9 +11,7 @@
   <title>Document</title>
 </head>
 <body>
-  <div id="loader">
-    <img src="./img/3d8064758e54ec662e076b6ca54aa90e.gif" alt="Loading...">
-  </div>
+  <div id="loader"></div>
 
   <div id="currentDateTime"></div>
 
@@ -21,9 +19,7 @@
     <span id="status-text"></span>
   </div>
 
-  <button onclick="speech()" id="assistantButton">
-    <img src="./img/главная кнопка.jpg" alt="Assistant Icon">
-  </button>
+  <button onclick="speech()" id="assistantButton"><i class="fas fa-microphone"></i></button>
 
   <div class="burger-menu">
     <p id="hidden-paragraph"></p>
@@ -44,24 +40,9 @@
         Светлая тема
       </label>
     </div>
-    <button onclick="toggleVisibility()">
-      <img src="./img/кнопка для меню.jpg" alt="Изображение кнопки">
-    </button>
+    <button onclick="toggleVisibility()" class="menu-toggle"><i class="fas fa-bars"></i></button>
   </div>
 
-  <div id="frame-icon">
-    <img class="frame-icon" src="./img/рамка для wifi.jpg" alt="Картинка">
-  </div>
-
-  <div id="logoFrame">
-    <img class="logoFrame" src="./img/рамка под логотип.jpg" alt="logo-frame">
-    <img class="custom-icon" src="./img/логотип1.jpg" alt="AI">
-  </div>
-
-  <div id="analysis">
-    <img class="frame-analysis" src="./img/рамка анализа .jpg" alt="frame-analysis">
-    <img class="analysis" src="./img/Аналитика.gif" alt="analysis">
-  </div>
 
   <script>
     window.addEventListener("load", function () {

--- a/s.css
+++ b/s.css
@@ -7,16 +7,13 @@ body {
   padding: 20px;
   width: 100%;
   min-height: 100vh;
-  background-image: url("./img/ФОН.jpg");
-  background-size: cover;
-  background-position: center;
-  background-attachment: fixed;
-  font-family: "Oswald", Arial, sans-serif;
+  background: linear-gradient(135deg, #1c1c1e, #2c2c2e);
+  font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+  color: #fff;
 }
 
 body.light-theme {
-  background-image: none;
-  background-color: #ffffff;
+  background: linear-gradient(135deg, #f5f5f7, #ffffff);
   color: #000;
 }
 
@@ -44,11 +41,27 @@ body.light-theme #menu-actions button {
   top: 0;
   width: 100%;
   height: 100%;
-  background-color: #000000;
+  background: rgba(255, 255, 255, 0.9);
   display: flex;
   justify-content: center;
   align-items: center;
   z-index: 9999;
+}
+
+#loader::after {
+  content: "";
+  width: 40px;
+  height: 40px;
+  border: 4px solid #e5e5ea;
+  border-top-color: #007aff;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 #currentDateTime {
@@ -61,12 +74,12 @@ body.light-theme #menu-actions button {
   display: flex;
   flex-direction: column;
   align-items: center;
-  color: #25b6aa;
-  background-image: url("./img/рамка\\ для\\ часов.jpg");
-  background-size: cover;
-  background-position: center;
+  color: #007aff;
+  background: rgba(255, 255, 255, 0.25);
+  backdrop-filter: blur(10px);
   justify-content: center;
   text-align: center;
+  border-radius: 12px;
   position: fixed;
   top: 1rem;
   right: 1rem;
@@ -80,53 +93,52 @@ body.light-theme #menu-actions button {
   height: 18vw;
   max-width: 80px;
   max-height: 80px;
-  background-color: #0b0c0c;
-  color: #000000;
-  font-size: 16px;
+  background: linear-gradient(135deg, #34c759, #007aff);
+  color: #fff;
+  font-size: 24px;
   border: none;
   border-radius: 50%;
   cursor: pointer;
-  overflow: hidden;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
   position: fixed;
   bottom: 20px;
   left: 50%;
   transform: translateX(-50%);
+  transition: background 0.3s;
 }
 
-#assistantButton img {
-  width: 100%;
-  height: 100%;
-  display: block;
+#assistantButton i {
+  pointer-events: none;
+}
+
+#assistantButton.listening {
+  animation: pulse 1.5s infinite;
+}
+
+@keyframes pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(0, 122, 255, 0.7);
+  }
+  70% {
+    box-shadow: 0 0 0 20px rgba(0, 122, 255, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(0, 122, 255, 0);
+  }
 }
 
 .burger-menu {
   position: relative;
-  color: #33b6d8ff;
-  border: none;
-  border-image: linear-gradient(45deg, #33b6d8ff, #00396eff, #33b6d8ff);
-  border-image-slice: 1;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(20px);
   overflow: auto;
   max-height: 50vh;
   align-self: flex-end;
   font-family: "Oswald", Arial, sans-serif;
   padding: 20px;
+  border-radius: 20px;
   box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.25);
-}
-
-.burger-menu::before {
-  content: "";
-  position: fixed;
-  bottom: 90px;
-  right: 0;
-  width: 40vw;
-  max-width: 200px;
-  height: 20vw;
-  max-height: 100px;
-  background-image: url(./img/рамка\\ для\\ меню\\ .jpg);
-  background-size: cover;
-  background-position: center;
-  z-index: -1;
 }
 
 #hidden-paragraph {
@@ -136,9 +148,7 @@ body.light-theme #menu-actions button {
   bottom: 150px;
   right: 20px;
   border: none;
-  background-image: url(./img/РАМКА\\ ПОД\\ ТЕКСТ.jpg);
-  background-size: cover;
-  background-position: center;
+  background: rgba(0, 0, 0, 0.6);
   overflow: auto;
   max-height: 50vh;
   align-self: flex-end;
@@ -146,6 +156,7 @@ body.light-theme #menu-actions button {
   text-align: center;
   font-size: 14px;
   margin-top: 10px;
+  border-radius: 8px;
 }
 
 #voice-controls {
@@ -246,19 +257,18 @@ body.light-theme #menu-actions button {
   bottom: 20px;
   right: 20px;
   border: none;
-  background: none;
+  background: linear-gradient(135deg, #ff9500, #ff2d55);
+  color: #fff;
   cursor: pointer;
-  padding: 0;
-  margin: 0;
-  display: inline-block;
-  vertical-align: middle;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border-radius: 50%;
-  overflow: hidden;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
 }
 
-.burger-menu img {
-  width: 100%;
-  height: 100%;
+.burger-menu button i {
+  pointer-events: none;
 }
 
 #status-text {
@@ -274,54 +284,6 @@ body.light-theme #menu-actions button {
   position: fixed;
   top: 30px;
   right: 80px;
-}
-
-.frame-icon {
-  display: block;
-  width: 18vw;
-  max-width: 70px;
-  height: auto;
-  position: fixed;
-  top: 0px;
-  right: 15vw;
-}
-
-.logoFrame {
-  display: block;
-  width: 18vw;
-  max-width: 70px;
-  height: auto;
-  position: fixed;
-  top: 0px;
-  right: calc(15vw + 18vw);
-}
-
-.custom-icon {
-  width: 14vw;
-  max-width: 50px;
-  height: auto;
-  position: fixed;
-  top: 18px;
-  right: calc(15vw + 18vw + 5vw);
-}
-
-.frame-analysis {
-  width: 55vw;
-  max-width: 240px;
-  height: auto;
-  position: fixed;
-  top: 0;
-  right: calc(15vw + 18vw + 18vw + 5vw);
-}
-
-.analysis {
-  display: block;
-  width: 50vw;
-  max-width: 215px;
-  height: auto;
-  position: fixed;
-  top: 5px;
-  right: calc(15vw + 18vw + 18vw + 8vw);
 }
 
 @media (min-width: 768px) {

--- a/script.js
+++ b/script.js
@@ -1,11 +1,17 @@
-
 let apiKey = 'тут должен бытть ваш api ключь '
-
 
 // ПЕРЕМЕННЫЕ
 let button = window.document.querySelector('button');
 let p = window.document.querySelector('p');
 let conversation = JSON.parse(localStorage.getItem('conversation') || '[]');
+
+const setDefaultButton = () => {
+  button.innerHTML = '<i class="fas fa-microphone"></i>';
+  button.classList.remove('listening');
+  button.style.animation = 'none';
+};
+
+setDefaultButton();
 
 
 // Для распознавания речи (кроссбраузерная инициализация)
@@ -22,9 +28,8 @@ if (speechRecognizer) {
     isListening = true;
   };
   speechRecognizer.onend = () => {
-    isListening = false;
-    button.innerHTML = '<img src="./img/кнопка.jpg">';
-    button.style.animation = 'none';
+      isListening = false;
+      setDefaultButton();
   };
 }
 
@@ -126,15 +131,14 @@ const speech = () => {
     talk('Ваш браузер не поддерживает распознавание речи');
     return;
   }
-  if (isListening) {
-    speechRecognizer.stop();
-    speechSynthesis.cancel();
-    button.innerHTML = '<img src="./img/кнопка.jpg">';
-    button.style.animation = 'none';
-  } else {
-    speechRecognizer.start();
-    button.innerHTML = '<img src="./img/говорите.gif" alt="Говорите">';
-  }
+    if (isListening) {
+      speechRecognizer.stop();
+      speechSynthesis.cancel();
+      setDefaultButton();
+    } else {
+      speechRecognizer.start();
+      button.classList.add('listening');
+    }
   isListening = !isListening;
 };
 
@@ -152,18 +156,17 @@ const talk = (text) => {
 
     utterance.onstart = () => {
       if (speechRecognizer && isListening) {
-        speechRecognizer.stop();
-        isListening = false;
-        button.innerHTML = '<img src="./img/кнопка.jpg">';
-        button.style.animation = 'none';
+          speechRecognizer.stop();
+          isListening = false;
+          setDefaultButton();
       }
     };
 
     utterance.onend = () => {
       if (speechRecognizer && !isListening) {
-        speechRecognizer.start();
-        isListening = true;
-        button.innerHTML = '<img src="./img/говорите.gif" alt="Говорите">';
+          speechRecognizer.start();
+          isListening = true;
+          button.classList.add('listening');
       }
     };
 
@@ -184,8 +187,8 @@ Authorization: `Bearer ${apiKey}`,
 
 const requestFunc = () => {
 if (p.innerText) {
-  button.innerHTML = '<img src="./img/60d2c1320c179e49c76c31ea08bc187e.gif">';//----- отправка
-button.style.animation = 'button_anim 2s infinite';
+    button.innerHTML = '<i class="fas fa-spinner fa-spin"></i>';//----- отправка
+    button.classList.remove('listening');
 
 const message = {
 role: 'user',
@@ -213,8 +216,7 @@ saveConversation();
 updateChatHistory();
 
 p.innerText = gptMessage.content;
-button.innerHTML = '<img src="./img/кнопка.jpg">';
-button.style.animation = 'none';
+  setDefaultButton();
 
 talk(p.innerText);
 } else {


### PR DESCRIPTION
## Summary
- restyle UI with iOS-inspired gradients and glassy components
- replace image buttons with FontAwesome icons and CSS animations
- remove outdated image-based assets from layout

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68abbd3ac110832aae9ff8a4470498ba